### PR TITLE
Allow custom resource constructor args

### DIFF
--- a/flask_rest_jsonapi/api.py
+++ b/flask_rest_jsonapi/api.py
@@ -69,7 +69,11 @@ class Api(object):
         resource.view = view
         url_rule_options = kwargs.get('url_rule_options') or dict()
 
-        view_func = resource.as_view(view)
+        # Allow the customization of the resource class instance
+        resource_args = kwargs.get('resource_args', [])
+        resource_kwargs = kwargs.get('resource_kwargs', {})
+
+        view_func = resource.as_view(view, *resource_args, **resource_kwargs)
 
         if 'blueprint' in kwargs:
             resource.view = '.'.join([kwargs['blueprint'].name, resource.view])

--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -52,7 +52,7 @@ class ResourceMeta(MethodViewType):
 class Resource(MethodView):
     """Base resource class"""
 
-    def __new__(cls):
+    def __new__(cls, *args, **kwargs):
         """Constructor of a resource instance"""
         if hasattr(cls, '_data_layer'):
             cls._data_layer.resource = cls

--- a/tests/test_sqlalchemy_data_layer.py
+++ b/tests/test_sqlalchemy_data_layer.py
@@ -991,7 +991,7 @@ class TestResourceArgs:
             This fake resource always renders a constructor parameter
             """
             def __init__(self, *args, **kwargs):
-                super().__init__()
+                super(TestResource, self).__init__()
                 self.constant = args[0]
 
             def get(self):
@@ -1009,7 +1009,7 @@ class TestResourceArgs:
             This fake resource always renders a constructor parameter
             """
             def __init__(self, *args, **kwargs):
-                super().__init__()
+                super(TestResource, self).__init__()
                 self.constant = kwargs.get('constant')
 
             def get(self):

--- a/tests/test_sqlalchemy_data_layer.py
+++ b/tests/test_sqlalchemy_data_layer.py
@@ -19,6 +19,7 @@ from flask_rest_jsonapi.querystring import QueryStringManager as QSManager
 from flask_rest_jsonapi.data_layers.alchemy import SqlalchemyDataLayer
 from flask_rest_jsonapi.data_layers.base import BaseDataLayer
 from flask_rest_jsonapi.data_layers.filtering.alchemy import Node
+from flask_rest_jsonapi.decorators import check_headers, check_method_requirements, jsonapi_exception_formatter
 import flask_rest_jsonapi.decorators
 import flask_rest_jsonapi.resource
 import flask_rest_jsonapi.schema
@@ -981,6 +982,46 @@ def test_get_list_response(client, register_routes):
     with client:
         response = client.get('/persons_response', content_type='application/vnd.api+json')
         assert response.status_code == 200
+
+
+class TestResourceArgs:
+    def test_resource_args(self, app):
+        class TestResource(ResourceDetail):
+            """
+            This fake resource always renders a constructor parameter
+            """
+            def __init__(self, *args, **kwargs):
+                super().__init__()
+                self.constant = args[0]
+
+            def get(self):
+                return self.constant
+        api = Api(app=app)
+        api.route(TestResource, 'resource_args', '/resource_args', resource_args=['hello!'])
+        api.init_app()
+        with app.test_client() as client:
+            rv = client.get('/resource_args')
+            assert rv.json == 'hello!'
+
+    def test_resource_kwargs(self, app):
+        class TestResource(ResourceDetail):
+            """
+            This fake resource always renders a constructor parameter
+            """
+            def __init__(self, *args, **kwargs):
+                super().__init__()
+                self.constant = kwargs.get('constant')
+
+            def get(self):
+                return self.constant
+        api = Api(app=app)
+        api.route(TestResource, 'resource_kwargs', '/resource_kwargs', resource_kwargs={
+            'constant': 'hello!'
+        })
+        api.init_app()
+        with app.test_client() as client:
+            rv = client.get('/resource_kwargs')
+            assert rv.json == 'hello!'
 
 
 # test various Accept headers


### PR DESCRIPTION
For example, this lets you do:

```python
class TestResource(ResourceDetail):
    """ 
    This fake resource always renders a constructor parameter
    """ 
    def __init__(self, *args, **kwargs):
        super().__init__()
        self.constant = kwargs.get('constant')

    def get(self):
        return self.constant

api.route(TestResource, 'resource_kwargs', '/resource_kwargs', resource_kwargs={
    'constant': 'hello!'
})
```

Basically this is helpful if you ever want to fully customize a resource object.