### PR TITLE
Support class-based content types

### DIFF
--- a/flapison/resource.py
+++ b/flapison/resource.py
@@ -62,21 +62,29 @@ class Resource(MethodView):
         return super(Resource, cls).__new__(cls)
 
     def __init__(self, endpoint=None, request_parsers=None, response_renderers=None):
-        # Start with default parsers, but accept user provided ones
-        self.request_parsers = {
+        # Start with default parsers, then combine them with class variables, and also
+        # constructor arguments
+        combined_parsers = {
             'application/vnd.api+json': parse_json,
             'application/json': parse_json
         }
+        if hasattr(self, 'request_parsers'):
+            combined_parsers.update(self.request_parsers)
         if request_parsers is not None:
-            self.request_parsers.update(request_parsers)
+            combined_parsers.update(request_parsers)
+        self.request_parsers = combined_parsers
 
-        # Start with default renderers, but accept user provided ones
-        self.response_renderers = {
+        # Start with default renderers, then combine them with class variables, and also
+        # constructor arguments
+        combined_renderers = {
             'application/vnd.api+json': render_json,
             'application/json': render_json
         }
+        if hasattr(self, 'response_renderers'):
+            combined_renderers.update(self.response_renderers)
         if response_renderers is not None:
-            self.response_renderers.update(response_renderers)
+            combined_renderers.update(response_renderers)
+        self.response_renderers = combined_renderers
 
         # By default we assign each Resource class with a view/endpoint. However if the
         # same resource is used for multiple routes, the endpoint will be overwritten.

--- a/tests/test_csv_content.py
+++ b/tests/test_csv_content.py
@@ -20,7 +20,7 @@ def client(app):
 
 @pytest.fixture()
 def register_routes(person_list, person_detail, person_computers, computer_list,
-                    computer_detail, computer_owner):
+                    computer_detail, computer_owner, app):
     def register(api):
         api.route(person_list, 'person_list', '/persons')
         api.route(person_detail, 'person_detail', '/persons/<int:person_id>')


### PR DESCRIPTION
e.g. 
```python
class TestResource(ResourceDetail):
    response_renderers = { 
        'text/fake_content': lambda x: make_response(str(x), 200, {
            'Content-Type': 'text/fake_content'
        })  
    }   
    request_parsers = { 
        'text/fake_content': str 
    }  
```