### PR TITLE
Fix QueryStringManager use wrong schema

### DIFF
--- a/flapison/querystring.py
+++ b/flapison/querystring.py
@@ -13,7 +13,7 @@ from flapison.exceptions import (
     InvalidField,
     InvalidInclude,
 )
-from flapison.schema import get_model_field, get_relationships, get_schema_from_type
+from flapison.schema import get_model_field, get_relationships
 
 
 class QueryStringManager(object):
@@ -177,11 +177,10 @@ class QueryStringManager(object):
                 result[key] = [value]
 
         for key, value in result.items():
-            schema = get_schema_from_type(key)
             for obj in value:
-                if obj not in schema._declared_fields:
+                if obj not in self.schema._declared_fields:
                     raise InvalidField(
-                        "{} has no attribute {}".format(schema.__name__, obj)
+                        "{} has no attribute {}".format(self.schema.__name__, obj)
                     )
 
         return result

--- a/flapison/schema.py
+++ b/flapison/schema.py
@@ -158,22 +158,6 @@ def get_related_schema(schema, field):
     return schema._declared_fields[field].__dict__["_Relationship__schema"]
 
 
-def get_schema_from_type(resource_type):
-    """Retrieve a schema from the registry by his type
-
-    :param str type_: the type of the resource
-    :return Schema: the schema class
-    """
-    for cls_name, cls in class_registry._registry.items():
-        try:
-            if cls[0].opts.type_ == resource_type:
-                return cls[0]
-        except Exception:
-            pass
-
-    raise Exception("Couldn't find schema for type: {}".format(resource_type))
-
-
 def get_schema_field(schema, field):
     """Get the schema field of a model field
 


### PR DESCRIPTION
Use self schema replace the schema get from `get_schema_from_type` in `QueryStringManager` property method `fields`. This change fix the bug when has multiple schema objects of the same type name.