### PR TITLE
log exceptions on non-api fails

### DIFF
--- a/flapison/decorators.py
+++ b/flapison/decorators.py
@@ -117,6 +117,7 @@ def jsonapi_exception_formatter(func):
         except Exception as e:
             if current_app.config["DEBUG"] is True:
                 raise e
+            current_app.log_exception(e)
 
             if "sentry" in current_app.extensions:
                 current_app.extensions["sentry"].captureException()

--- a/tests/test_content_type.py
+++ b/tests/test_content_type.py
@@ -223,7 +223,10 @@ def test_accept_no_accept(person, person_2, client, registered_routes):
     Check that a request without an Accept header works
     """
     response = client.get(
-        "/persons", headers={"Content-Type": "application/vnd.api+json",}
+        "/persons",
+        headers={
+            "Content-Type": "application/vnd.api+json",
+        },
     )
 
     assert response.status_code == 200, response.json
@@ -254,7 +257,10 @@ def test_accept_charset(person, person_2, client, registered_routes):
     Check that a request with a valid Accept header but a charset parameter works
     """
     response = client.get(
-        "/persons", headers={"Accept": "application/vnd.api+json; charset=utf-8",}
+        "/persons",
+        headers={
+            "Accept": "application/vnd.api+json; charset=utf-8",
+        },
     )
 
     assert response.status_code == 200, response.json

--- a/tests/test_sqlalchemy_data_layer.py
+++ b/tests/test_sqlalchemy_data_layer.py
@@ -504,7 +504,11 @@ def test_get_detail(client, registered_routes, person):
 
 def test_get_detail_with_sparse_fieldsets(client, registered_routes, person):
     with client:
-        querystring = urlencode({"fields[person]": "name",})
+        querystring = urlencode(
+            {
+                "fields[person]": "name",
+            }
+        )
         response = client.get(
             "/persons/" + str(person.person_id) + "?" + querystring,
             content_type="application/vnd.api+json",
@@ -752,7 +756,9 @@ def test_resource_kwargs(app):
         TestResource,
         "resource_kwargs",
         "/resource_kwargs",
-        resource_kwargs={"constant": "hello!",},
+        resource_kwargs={
+            "constant": "hello!",
+        },
     )
     api.init_app()
     with app.test_client() as client:
@@ -1336,7 +1342,13 @@ def test_post_relationship_missing_type(client, registered_routes, computer, per
 
 
 def test_post_relationship_missing_id(client, registered_routes, computer, person):
-    payload = {"data": [{"type": "computer",}]}
+    payload = {
+        "data": [
+            {
+                "type": "computer",
+            }
+        ]
+    }
 
     with client:
         response = client.post(
@@ -1432,7 +1444,13 @@ def test_patch_relationship_missing_type(client, registered_routes, computer, pe
 
 
 def test_patch_relationship_missing_id(client, registered_routes, computer, person):
-    payload = {"data": [{"type": "computer",}]}
+    payload = {
+        "data": [
+            {
+                "type": "computer",
+            }
+        ]
+    }
 
     with client:
         response = client.patch(
@@ -1528,7 +1546,13 @@ def test_delete_relationship_missing_type(client, registered_routes, computer, p
 
 
 def test_delete_relationship_missing_id(client, registered_routes, computer, person):
-    payload = {"data": [{"type": "computer",}]}
+    payload = {
+        "data": [
+            {
+                "type": "computer",
+            }
+        ]
+    }
 
     with client:
         response = client.delete(


### PR DESCRIPTION
If not using debug mode, non-`JsonApiException`s are only returned to the requestor and not logged. This makes it difficult to detect when requests are failing and what is causing the exceptions.